### PR TITLE
feat: golang new versions does not have this property, instead static…

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -22,13 +22,17 @@ type Conn struct {
 	mu sync.RWMutex
 }
 
+const (
+	NETLINK_NETFILTER = 12
+)
+
 // Dial opens a new Netlink connection to the Netfilter subsystem
 // and returns it wrapped in a Conn structure.
 func Dial(config *netlink.Config) (*Conn, error) {
 	var c Conn
 	var err error
 
-	c.conn, err = netlink.Dial(unix.NETLINK_NETFILTER, config)
+	c.conn, err = netlink.Dial(NETLINK_NETFILTER, config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
New version of Golang (1.23,1.24) does not provide NETLINK_NETFILTER, so I embed variable into package